### PR TITLE
add producer version (fencing token)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@ curl -X POST "https://your-worker.example.com/your-stream-name" \
   }'
 ```
 
+#### Publish version (fencing token)
+
+You can optionally include a version parameter when publishing to implement fencing tokens or leader election:
+
+```
+curl -X POST "https://your-worker.example.com/your-stream-name?version=1" \
+  -H "Content-Type: application/json" \
+  -H "auth: YOUR_AUTH_HEADER" \
+  -d '{
+    "records": [{"key": "value1"}]
+  }'
+```
+
+The version acts as a fencing token:
+
+- Must be a number
+- Only allows writes if version >= current version
+- Updates stored version when a higher version is provided
+- Returns 409 if version < current version
+- Optional - if not provided, writes are always allowed
+
+This is useful for:
+
+- Preventing stale/zombie producers from writing
+- Handling changes in higher-level partition rebalancing (prevent producers from writing to the wrong partition during inconsistency window of producer and partition count)
+
 ### Consuming
 
 To consume messages, perform a GET request to the stream:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl -X POST "https://your-worker.example.com/your-stream-name?version=1" \
   -H "Content-Type: application/json" \
   -H "auth: YOUR_AUTH_HEADER" \
   -d '{
-    "records": [{"key": "value1"}]
+    "records": []
   }'
 ```
 
@@ -49,6 +49,12 @@ This is useful for:
 
 - Preventing stale/zombie producers from writing
 - Handling changes in higher-level partition rebalancing (prevent producers from writing to the wrong partition during inconsistency window of producer and partition count)
+
+You can choose to omit records when publishing to purely increment the producer version, which can be used between creating the new partition (and making it available for discovery), and before pushing updates down the publishers, to consistently handle rebalancing. That will return the following JSON response:
+
+```
+{ version: this.metadata.producer_version }
+```
 
 ### Consuming
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,6 +257,11 @@ export class StreamCoordinator extends DurableObject<Env> {
 			}
 		}
 
+		if (body.records.length === 0) {
+			// We probably just incremented the version
+			return new Response(JSON.stringify({ version: this.metadata.producer_version }), { status: 200 })
+		}
+
 		// Submit for persistence and wait
 		const emitter = new EventEmitter<{ resolve: [string[]]; error: [Error] }>()
 		this.pendingMessages.push({ emitter, records: body.records.map((r) => JSON.stringify(r)) })


### PR DESCRIPTION
Adds a producer version to serve as a fencing token for higher level constructs like partitions.

When you rebalance partitions, you run into a consistency ordering issue for where some period of time some publishers might write to one partition, and some to another, because not everyone has received the partitions update yet. This can help with that if you first push a fencing token update, then emit info about the new partition, producers can then realize this and fetch updated metadata.